### PR TITLE
Remove Base64 thumbnail experiment

### DIFF
--- a/templates/timeline.html
+++ b/templates/timeline.html
@@ -1,6 +1,3 @@
-{%- macro placeholder_img(placeholder) -%}
-style="background-size: cover; background-repeat: no-repeat; background-image: url(data:image/png;base64,{{ placeholder }});"
-{%- endmacro -%}
 {%- set page_current = "/timeline" -%}
 {%- extends "shared/base.html" -%}
 {%- from "shared/header-nav.html" import nav_head, nav_content -%}
@@ -110,7 +107,7 @@ style="background-size: cover; background-repeat: no-repeat; background-image: u
       {%- if event.media.path and event.media.width and event.media.height %}
         {%- if event.media.is_youtube and event.media.video_id %}
         <div class="video placeholder" data-video_id="{{event.media.video_id}}" {%- if event.media.video_start -%}data-video_start="{{event.media.video_start}}"{%- endif -%}>
-          <img src="{{ event.media.path }}" loading="lazy" width="{{ event.media.width }}" height="{{ event.media.height }}" {{ placeholder_img(event.media.placeholder) }}>
+          <img src="{{ event.media.path }}" loading="lazy" width="{{ event.media.width }}" height="{{ event.media.height }}">
           <play-icon>
             <circle></circle>
             <triangle></triangle>
@@ -118,7 +115,7 @@ style="background-size: cover; background-repeat: no-repeat; background-image: u
         </div>
         {%- else %}
         <a href="{{ event.media.link }}" target="_blank">
-          <img src="{{ event.media.path }}" loading="lazy" width="{{ event.media.width }}" height="{{ event.media.height }}" {{ placeholder_img(event.media.placeholder) }}>
+          <img src="{{ event.media.path }}" loading="lazy" width="{{ event.media.width }}" height="{{ event.media.height }}">
         </a>
         {%- endif %}
       {%- endif %}


### PR DESCRIPTION
This PR is for Issue https://github.com/BaeMillion/operation-mm/issues/5 and removes the Base64-encoded placeholder thumbnails from an earlier commit. With this PR we can have two versions of the site (with and without thumbnails) deployed on GitHub Pages to test.