### PR TITLE
Ensure newlines are respected in Message content

### DIFF
--- a/public/styles/messages.css
+++ b/public/styles/messages.css
@@ -154,6 +154,10 @@ img.emoji {
     padding: 1rem;
     border: 5px solid rgb(0 0 0 / 0);
     z-index: 0;
+
+    p {
+      white-space: break-spaces;
+    }
   }
 
   .msg-img {

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -74,7 +74,7 @@
         data-full-img="{{msg.media.path}}" data-full-width="{{ msg.media.width }}" data-full-height="{{ msg.media.height }}"
       >
     {% endif -%}
-      <p>{{ msg.message }}</p>
+      <p>{{ msg.message | replace('\n', '<br>') | safe }}</p>
     </div>
   </div>
   {%- endfor %}

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -74,7 +74,7 @@
         data-full-img="{{msg.media.path}}" data-full-width="{{ msg.media.width }}" data-full-height="{{ msg.media.height }}"
       >
     {% endif -%}
-      <p>{{ msg.message | replace('\n', '<br>') | safe }}</p>
+      <p>{{ msg.message }}</p>
     </div>
   </div>
   {%- endfor %}


### PR DESCRIPTION
Message submissions contain newlines that people wish to have in their message for the formatting. These newlines pass through the data processing and are rendered into the HTML by minijinja.

![image](https://github.com/user-attachments/assets/bb2f4e16-134e-45d2-89e6-d4d201c9c736)

However HTML does not care if you've got '\n' inside of a paragraph, `<p>`, and renders those newlines as spaces. So we have to tell the HTML that we want the whitespace respected, newlines and all. This is accomplished with the CSS property, `white-space: break-spaces`. https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

## Before
![image](https://github.com/user-attachments/assets/9603265a-cd33-48aa-ae54-f4018fabcbc7)

## After
![image](https://github.com/user-attachments/assets/bdf727e9-84ba-4f7c-b1c4-36f5fb66fe26)
